### PR TITLE
Augmented end2end section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,25 @@ cargo leptos build --release
 Will generate your server binary in target/server/release and your site package in target/site
 
 ## Testing Your Project
+
+Cargo-leptos uses (https://playwright.dev)[Playwright] as the end-to-end test tool. 
+
+Prior to the first run of the end-to-end tests run Playwright must be installed. 
+In the project's `end2end` directory run `npm install -D playwright @playwright/test` to install playwright and browser specific APIs.
+
+To run the tests during development in the project root run:
 ```bash
 cargo leptos end-to-end
 ```
 
+To run tests for release in the project root run:
 ```bash
 cargo leptos end-to-end --release
 ```
+There are some examples tests are located in `end2end/tests` directory that pass tests with the sample Leptos app.
 
-Cargo-leptos uses Playwright as the end-to-end test tool.  
-Tests are located in end2end/tests directory.
+A web-based report on tests is available by running `npx playwright show-report` in the `end2end` directory.
+
 
 ## Executing a Server on a Remote Machine Without the Toolchain
 After running a `cargo leptos build --release` the minimum files needed are:


### PR DESCRIPTION
When I attempted to run end-to-end test in the [start-axum-workspace](https://github.com/leptos-rs/start-axum-workspace) generated project they failed to run. I found out that I didn't have all the dependencies installed. The README.md didn't give me the information needed. I've augmented the README.md to include the necessary information to run end-to-end tests.