### PR TITLE
Fix project name placeholder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wasm-bindgen = "=0.2.100"
 # that are used together frontend (lib) & server (bin)
 [[workspace.metadata.leptos]]
 # this name is used for the wasm, js and css file names
-name = "start-axum-workspace"
+name = "{{project-name}}"
 
 # the package in the workspace that contains the server binary (binary crate)
 bin-package = "server"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cargo leptos new --git https://github.com/leptos-rs/start-axum-workspace/
 to generate a new project template.
 
 ```bash
-cd {projectname}
+cd {{project-name}}
 ```
 
 to go to your newly created project.  
@@ -92,12 +92,12 @@ After running a `cargo leptos build --release` the minimum files needed are:
 
 Copy these files to your remote server. The directory structure should be:
 ```text
-start-axum-workspace
+{{project-name}}
 site/
 ```
 Set the following environment variables (updating for your project as needed):
 ```text
-LEPTOS_OUTPUT_NAME="start-axum-workspace"
+LEPTOS_OUTPUT_NAME="{{project-name}}"
 LEPTOS_SITE_ROOT="site"
 LEPTOS_SITE_PKG_DIR="pkg"
 LEPTOS_SITE_ADDR="127.0.0.1:3000"

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -29,7 +29,7 @@ pub fn App() -> impl IntoView {
     provide_meta_context();
 
     view! {
-        <Stylesheet id="leptos" href="/pkg/start-axum-workspace.css"/>
+        <Stylesheet id="leptos" href="/pkg/{{project-name}}.css"/>
 
         // sets the document title
         <Title text="Welcome to Leptos"/>


### PR DESCRIPTION
When running the command:
```bash
cargo leptos new --git https://github.com/leptos-rs/start-axum-workspace/
```
to generate a new project from the template, some files still contain the placeholder  `start-axum-workspace` instead of the actual project name chosen by the user.